### PR TITLE
Fix #1 Enable EditorConfig spec test through editorconfig-core-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,11 @@ nb-configuration.xml
 
 # OSX
 .DS_Store
+
+# CMake
+/CMakeFiles/
+/CMakeCache.txt
+/CTestTestfile.cmake
+/cmake_install.cmake
+/Makefile
+/Testing/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "editorconfig-core-test"]
+	path = editorconfig-core-test
+	url = https://github.com/editorconfig/editorconfig-core-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+# Enable container-based infrastructure
+# see https://docs.travis-ci.com/user/reference/overview/
+sudo: false
 
 jdk:
   - oraclejdk8
@@ -6,5 +9,10 @@ jdk:
 notifications:
   email: true
 
+install:
+- cmake --version
+- git submodule init
+- git submodule update
+
 script:
-- ./mvnw clean install
+- ./mvnw -Pcore-test clean install && cmake . && ctest .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+# This file is used for testing only
+
+# To perform the test, run `cmake .` at the root of the project tree followed
+# by ctest .
+
+cmake_minimum_required(VERSION 2.6)
+
+# Do not check any compiler
+project(org.eclipse.ec4j NONE)
+
+find_package(Java 1.6)
+
+if(NOT JAVA_FOUND)
+    message(FATAL_ERROR
+        "Java not found. If you have Java installed, please run:
+        cmake -DJAVA_HOME=/path/to/java .")
+endif()
+
+enable_testing()
+set(EDITORCONFIG_CMD ${Java_JAVA_EXECUTABLE} -cp ${PROJECT_SOURCE_DIR}/target/org.eclipse.ec4j.jar org.eclipse.ec4j.cli.Cli)
+add_subdirectory(editorconfig-core-test)

--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,7 @@ Prerequisites:
 
 * Java 7+
 * Optionally Maven 3.5.0+, unless you want to use `./mvnw` or `mvnw.bat` delivered by the project
+* cmake 2.6+ to run the https://github.com/editorconfig/editorconfig-core-test[editorconfig-core-test] testsuite (optional).
 
 The most common build with unit tests:
 
@@ -31,9 +32,19 @@ The most common build with unit tests:
 ----
 
 On Windows:
+
 [source,shell]
 ----
 mvnw.bat clean instal
+----
+
+A build with https://github.com/editorconfig/editorconfig-core-test[editorconfig-core-test] testsuite:
+
+[source,shell]
+----
+git submodule init
+git submodule update
+mvn -Pcore-test clean install && cmake . && ctest .
 ----
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,4 +112,14 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<!-- core-test profile to produce a jar file with a version-less name as it is expected by cmake tests -->
+		<profile>
+			<id>core-test</id>
+			<build>
+				<finalName>${project.artifactId}</finalName>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/src/main/java/org/eclipse/ec4j/cli/Cli.java
+++ b/src/main/java/org/eclipse/ec4j/cli/Cli.java
@@ -1,0 +1,90 @@
+/**
+ *  Copyright (c) 2017 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package org.eclipse.ec4j.cli;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.ec4j.EditorConfigConstants;
+import org.eclipse.ec4j.EditorConfigManager;
+import org.eclipse.ec4j.model.Option;
+import org.eclipse.ec4j.model.optiontypes.OptionTypeRegistry;
+
+/**
+ * A simple command line wrapper over {@link EditorConfigManager} so that it can
+ * be tested against <a href=
+ * "https://github.com/editorconfig/editorconfig-core-test">editorconfig-core-test</a>
+ * <p>
+ * The current class is based on <a href=
+ * "https://github.com/editorconfig/editorconfig-core-java/blob/8f9cf27964a6be1f385594d85c2f1eb587290561/src/main/java/org/editorconfig/EditorConfigCLI.java">EditorConfigCLI</a>
+ * by Dennis Ushakov.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public class Cli {
+	public static void main(String[] args) throws Exception {
+		List<String> paths = new ArrayList<>();
+		String editorconfigFileName = EditorConfigConstants.EDITORCONFIG;
+		String version = EditorConfigManager.VERSION;
+		for (int i = 0; i < args.length; i++) {
+			String arg = args[i];
+			switch (arg) {
+			case "-b":
+				if (i + 1 < args.length) {
+					version = args[++i];
+					continue;
+				} else {
+					System.err.println("-b option must be followed by a version");
+					System.exit(1);
+				}
+				break;
+			case "-f":
+				if (i + 1 < args.length) {
+					editorconfigFileName = args[++i];
+					continue;
+				} else {
+					System.err.println("-f option must be followed by a file path");
+					System.exit(1);
+				}
+				break;
+			case "--version":
+			case "-v":
+				break;
+			default:
+				paths.add(args[i]);
+				break;
+			}
+		}
+
+		if (paths.isEmpty()) {
+			System.err.println("At least one file path needs to be specified");
+			System.exit(1);
+		}
+
+		EditorConfigManager editorConfigManager = new EditorConfigManager(OptionTypeRegistry.DEFAULT,
+				editorconfigFileName, version);
+		Set<File> roots = Collections.singleton(new File(".").getAbsoluteFile());
+		for (String path : paths) {
+			if (paths.size() > 1) {
+				System.out.println("[" + path + "]");
+			}
+			Collection<Option> opts = editorConfigManager.getOptions(new File(path).getAbsoluteFile(), roots);
+			for (Option opt : opts) {
+				System.out.println(opt.getName() + "=" + opt.getValue());
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
@angelozerr now the tough part: the spec tests. While the tests should be set up properly, the success rate is quite small:

```
21% tests passed, 144 tests failed out of 182
```

The README describes how to run them (although I have no idea whether they can be run also on Windows). I have set Travis up to run them too.