### PR TITLE
Fix #14 (Fixup) Let travis show separate badges for unit tests and for

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ jdk:
 # Setting the same var twice in the env actually makes Travis create a matrix
 # - i.e. there will be two separate executions, one for each value
 env:
-  - CMD="./mvnw clean test"
-  - CMD="./mvnw -Pcore-test clean package -DskipTests && cmake . && ctest ."
-
+  global:
+  # GH_STATUS_USER_PASSWORD=<ghUser>:<ghAccessToken>
+  - secure: "Sna4UEFYnaV6k75xP5ZGMBaeBJTgZVczfX1YQLqL2bVgTLK0yqJFvYMtNVLHclMzX+MJVNCwHc5ajWXtgwhm/3LYoRpW07bj9u9iznd2flI59+wGEVprx6exAexGoTjELZtFzPW44/za/dfJtfJcAu3HEt1/JwJMRDbSN2Zc1gGQHywdC71c+0qxHDclAfrFOKRTmecTtOdxFwmvq9yTDo6OZzI+u9jBw2sfjwWwkBqGhlSZjZT4Mx6TWl70kVr1Dwo72VUQdEjPt7p/Z3+sWmzQIfCF40OzPmWPISjLU5FR02LoVKy6WRDZx1tzg5yqkidxHYxH5xHL4YEw0rvOeJDs5nLg9h99q/DHh3bhxW+cIbO+JvEGN1Fn7m5OLOHZ19Y+GE825kIBrdxHgWCG+Bt4O4kYr8Mdkb/OKi6W6k9ku8wziYu7uimQ6G81FYMvMKvjp8pyulMScDWtXdl/YKoOJyIfRS2SriwVszxtHuF1ZJhZ1F+h2Bo6YanhtGWqMCLwXj8iQdBFd67Mq4JHsaMyALWASoQ1EdEbfBCYG7+5SzNEkC/K/4mNRwJWA9BIf6D47DOXwZmGx6nj67LQwK3IvjdQY9yuEesS2Lu97k9a/wB4QEzDmpS5Tlb9b7tNAq18H21PP3tfS/77YktRWHBSv3pzldsSyLYjJ7K9R4o="
+  matrix:
+  - CMD="./mvnw clean test" JOB_LABEL="unit-tests"
+  - CMD="./mvnw -Pcore-test clean package -DskipTests && cmake . && ctest ." JOB_LABEL="core-tests"
+    
 notifications:
   email: true
 
@@ -20,5 +24,14 @@ install:
 - git submodule init
 - git submodule update
 
+before_script:
+- src/build/sh/github-comit-status.sh "${GH_STATUS_USER_PASSWORD}" "${JOB_LABEL}" "pending"
+
 script:
 - eval $CMD
+
+after_success:
+- src/build/sh/github-comit-status.sh "${GH_STATUS_USER_PASSWORD}" "${JOB_LABEL}" "success"
+
+after_failure:
+- src/build/sh/github-comit-status.sh "${GH_STATUS_USER_PASSWORD}" "${JOB_LABEL}" "failure"

--- a/src/build/sh/github-comit-status.sh
+++ b/src/build/sh/github-comit-status.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+# ${githubUser}:${apiToken}, should be kept secret
+# The API token can be created here: https://github.com/settings/tokens
+# it should have at least the repo:status scope.
+githubUserPassword="$1"
+
+# A label that describes the current job, typically some sort of concatenation of OS and env.
+jobLabel="$2"
+
+# state is one of error, failure, pending, or success
+state="$3"
+
+
+case "$TRAVIS_EVENT_TYPE" in
+pull_request)
+    travisEventType="pr"
+    ;;
+*) echo "Job commit status will not be set for TRAVIS_EVENT_TYPE '${TRAVIS_EVENT_TYPE}'"
+    exit 0
+    ;;
+esac
+
+
+case "$state" in
+error)
+    description="${jobLabel} exited with an error"
+    ;;
+failure)
+    description="${jobLabel} failed"
+    ;;
+pending)
+    description="${jobLabel} is pending"
+    ;;
+success)
+    description="${jobLabel} succeeded"
+    ;;
+*) echo "Unexpected state '${state}'"
+    exit 1
+    ;;
+esac
+
+
+# TRAVIS_COMMIT: The commit that the current build is testing.
+# TRAVIS_REPO_SLUG: The slug (in form: owner_name/repo_name) of the repository currently being built.
+# TRAVIS_TEST_RESULT: is set to 0 if the build is successful and 1 if the build is broken.
+# TRAVIS_PULL_REQUEST_SHA:
+#    if the current job is a pull request, the commit SHA of the HEAD commit of the PR.
+#    if the current job is a push build, this variable is empty ("").
+
+# POST /repos/:owner/:repo/statuses/:sha
+
+body=$(cat <<EOF
+{
+  "state": "${state}",
+  "target_url": "https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID}",
+  "description": "${description}",
+  "context": "continuous-integration/travis-ci/${travisEventType}/${jobLabel}"
+}
+EOF
+)
+
+curl -u "${githubUserPassword}" --verbose -X POST --data "${body}" https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_PULL_REQUEST_SHA}


### PR DESCRIPTION
editorconfig-core tests

@angelozerr, do not merge, your edit is need before merging.

This is finally doing exactly what I wanted:

![image](https://user-images.githubusercontent.com/1826249/31320551-aac04372-ac76-11e7-8860-db732fe832ea.png)

The only quirk is that the two new subjob status lines are created by directly invoking the GitHub REST API from the Travis script - see https://github.com/angelozerr/ec4j/commit/8ef764f388c52c2858741d1b3c0a01f96cc2fa2f#diff-354f30a63fb0907d4ad57269548329e3R28 and https://github.com/angelozerr/ec4j/commit/8ef764f388c52c2858741d1b3c0a01f96cc2fa2f#diff-1f09b1d8ada331d5ec012633d69a49d2R64

The present PR is using my GitHUb username and my GitHub API token and therefore works only for PRs sent against my fork of ec4j. For this to work with yours angelozerr/ec4j, you need to:

(1) Create an API token with repo:status scope on https://github.com/settings/tokens

(2) Install the `travis` ruby gem (I hope there is a way to install it on your OS): https://github.com/travis-ci/travis.rb#installation

(3) Encrypt the var=token pair with `travis encrypt -r angelozerr/ec4j GH_STATUS_USER_PASSWORD=angelozerr:<your_token>`

(4) Replace my encrypted env var (starting with `Sna4UEFY...`) with yours - the result of (3) https://github.com/angelozerr/ec4j/commit/8ef764f388c52c2858741d1b3c0a01f96cc2fa2f#diff-354f30a63fb0907d4ad57269548329e3R14

Feel free to cherry-pick my commit, amend it and send as a new PR so that we see that it works. We'll simply close the current PR then.