### PR TITLE
 Fix #42 EditorConfig, Section, Option with location

### DIFF
--- a/core/src/main/java/org/eclipse/ec4j/core/model/Adaptable.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/model/Adaptable.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2017 Angelo Zerr and other contributors as
+ * indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.ec4j.core.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A base for some model classes that allows to extend the default model without having to bother with Java inheritance
+ * and generics.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public abstract class Adaptable {
+
+    /**
+     * An {@link Adaptable} builder.
+     *
+     * @param <B>
+     *            the type of the extending builder
+     */
+    public abstract static class Builder<B extends Builder<B>> {
+        protected List<Object> adapters = null;
+
+        /**
+         * Adds a single {@code adapter}
+         *
+         * @param adapter
+         *            the adapter to add
+         * @return this {@link Builder}
+         */
+        @SuppressWarnings("unchecked")
+        public B adapter(Object adapter) {
+            if (this.adapters == null) {
+                this.adapters = new ArrayList<>();
+            }
+            this.adapters.add(adapter);
+            return (B) this;
+        }
+
+        /**
+         * Adds multiple {@code adapter}s
+         *
+         * @param adapters
+         *            the adapters to add
+         * @return this {@link Builder}
+         */
+        @SuppressWarnings("unchecked")
+        public B adapters(Collection<Object> adapters) {
+            if (this.adapters == null) {
+                this.adapters = new ArrayList<>(adapters);
+            } else {
+                this.adapters.addAll(adapters);
+            }
+            return (B) this;
+        }
+
+        /**
+         * Adds multiple {@code adapter}s
+         *
+         * @param adapters
+         *            the adapters to add
+         * @return this {@link Builder}
+         */
+        @SuppressWarnings("unchecked")
+        public B adapters(Object... adapters) {
+            if (this.adapters == null) {
+                this.adapters = new ArrayList<>(adapters.length);
+            }
+            for (Object adapter : adapters) {
+                this.adapters.add(adapter);
+            }
+            return (B) this;
+        }
+
+        /**
+         * Returns an immutable {@link List} of adapters and invalidates this {@link Builder}.
+         *
+         * @return an immutable {@link List} of adapters
+         */
+        protected List<Object> sealAdapters() {
+            if (adapters == null) {
+                return Collections.emptyList();
+            } else {
+                List<Object> useAdapters = this.adapters;
+                this.adapters = null;
+                return Collections.unmodifiableList(useAdapters);
+            }
+        }
+
+    }
+
+    private final List<Object> adapters;
+
+    Adaptable(List<Object> adapters) {
+        super();
+        this.adapters = adapters;
+    }
+
+    /**
+     * @param type
+     *            the type of the adapter to lookup
+     * @return the adapter of the given type or {@code null} if an adapter for the given type is not available
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getAdapter(Class<T> type) {
+        /* Try the exact match first */
+        for (Object o : adapters) {
+            if (type == o.getClass()) {
+                return (T) o;
+            }
+        }
+        /* Otherwise try to return a subclass */
+        for (Object o : adapters) {
+            if (type.isAssignableFrom(o.getClass())) {
+                return (T) o;
+            }
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/org/eclipse/ec4j/core/model/EditorConfig.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/model/EditorConfig.java
@@ -30,12 +30,12 @@ import org.eclipse.ec4j.core.model.propertytype.PropertyTypeRegistry;
  * @author <a href="mailto:angelo.zerr@gmail.com">Angelo Zerr</a>
  * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  */
-public class EditorConfig {
+public class EditorConfig extends Adaptable {
 
     /**
      * An {@link EditorConfig} builder.
      */
-    public static class Builder {
+    public static class Builder extends Adaptable.Builder<Builder> {
         final PropertyTypeRegistry registry;
 
         ResourcePath resourcePath;
@@ -55,7 +55,7 @@ public class EditorConfig {
         public EditorConfig build() {
             List<Section> useSections = sections;
             sections = null;
-            return new EditorConfig(root, version, resourcePath, Collections.unmodifiableList(useSections));
+            return new EditorConfig(sealAdapters(), root, version, resourcePath, Collections.unmodifiableList(useSections));
         }
 
         /**
@@ -171,15 +171,16 @@ public class EditorConfig {
     private final Version version;
 
     /**
-     * You look for {@link #builder(PropertyTypeRegistry)} if you wonder why this constructor this package private.
+     * You look for {@link #builder(PropertyTypeRegistry)} if you wonder why this constructor is package visible.
      *
+     * @param adapters
      * @param root
      * @param version
      * @param resourcePath
      * @param sections
      */
-    EditorConfig(Boolean root, Version version, ResourcePath resourcePath, List<Section> sections) {
-        super();
+    EditorConfig(List<Object> adapters, Boolean root, Version version, ResourcePath resourcePath, List<Section> sections) {
+        super(adapters);
         this.root = root;
         this.version = version;
         this.resourcePath = resourcePath;

--- a/core/src/main/java/org/eclipse/ec4j/core/model/Property.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/model/Property.java
@@ -16,6 +16,8 @@
  */
 package org.eclipse.ec4j.core.model;
 
+import java.util.List;
+
 import org.eclipse.ec4j.core.model.propertytype.PropertyException;
 import org.eclipse.ec4j.core.model.propertytype.PropertyName;
 import org.eclipse.ec4j.core.model.propertytype.PropertyType;
@@ -26,9 +28,13 @@ import org.eclipse.ec4j.core.model.propertytype.PropertyType;
  * @author <a href="mailto:angelo.zerr@gmail.com">Angelo Zerr</a>
  * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  */
-public class Property {
+public class Property extends Adaptable {
 
-    public static class Builder {
+
+    /**
+     * A {@link Property} builder.
+     */
+    public static class Builder extends Adaptable.Builder<Builder> {
 
         static boolean isValid(PropertyType<?> type, String value) {
             if (type == null) {
@@ -45,8 +51,10 @@ public class Property {
         /**
          * Return the lowercased value for certain properties.
          *
-         * @param propertyName the {@link PropertyName}
-         * @param value the value to transform
+         * @param propertyName
+         *            the {@link PropertyName}
+         * @param value
+         *            the value to transform
          * @return the transformed value or the same {@code value} as was passed in if no transformation was necessary
          */
         private static String preprocessValue(PropertyName propertyName, String value) {
@@ -95,7 +103,7 @@ public class Property {
          */
         public Section.Builder closeProperty() {
             if (checkMax()) {
-                Property property = new Property(type, name, value, parsedValue, valid);
+                Property property = new Property(sealAdapters(), type, name, value, parsedValue, valid);
                 parentBuilder.property(property);
             }
             return parentBuilder;
@@ -136,24 +144,30 @@ public class Property {
     private final Object parsedValue;
 
     private final String sourceValue;
+
     private final PropertyType<?> type;
     private final boolean valid;
+
     /**
      * Use the {@link Builder} if you cannot access this constructor
+     *
+     * @param adapters
      * @param type
      * @param name
      * @param sourceValue
      * @param parsedValue
      * @param valid
      */
-    Property(PropertyType<?> type, String name, String sourceValue, Object parsedValue, boolean valid) {
-        super();
+    Property(List<Object> adapters, PropertyType<?> type, String name, String sourceValue, Object parsedValue,
+            boolean valid) {
+        super(adapters);
         this.type = type;
         this.name = name;
         this.sourceValue = sourceValue;
         this.parsedValue = parsedValue;
         this.valid = valid;
     }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj)

--- a/core/src/main/java/org/eclipse/ec4j/core/model/Section.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/model/Section.java
@@ -28,22 +28,23 @@ import org.eclipse.ec4j.core.model.propertytype.PropertyType;
 import org.eclipse.ec4j.core.model.propertytype.PropertyTypeRegistry;
 
 /**
- * A section in an {@code .editorconfig} file. A section consists of a {@link Glob} and a collection of {@link Property}s.
+ * A section in an {@code .editorconfig} file. A section consists of a {@link Glob} and a collection of
+ * {@link Property}s.
  *
  * @author <a href="mailto:angelo.zerr@gmail.com">Angelo Zerr</a>
  * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  */
-public class Section {
+public class Section extends Adaptable {
 
     /**
      * A {@link Section} builder.
      */
-    public static class Builder {
+    public static class Builder extends Adaptable.Builder<Builder> {
 
         private Glob glob;
 
-        private Map<String, Property> properties = new LinkedHashMap<>();
         final EditorConfig.Builder parentBuilder;
+        private Map<String, Property> properties = new LinkedHashMap<>();
 
         /**
          * Constructs a new {@link Builder}
@@ -61,7 +62,7 @@ public class Section {
          */
         public Section build() {
             preprocessProperties();
-            return new Section(glob, Collections.unmodifiableList(new ArrayList<Property>(properties.values())));
+            return new Section(sealAdapters(), glob, Collections.unmodifiableList(new ArrayList<Property>(properties.values())));
         }
 
         /**
@@ -91,44 +92,8 @@ public class Section {
         }
 
         /**
-         * Adds the given {@link Property} to {@link #properties}.
-         *
-         * @param property the {@link Property} to add
-         * @return this {@link Builder}
-         */
-        public Builder property(Property property) {
-            this.properties.put(property.getName(), property);
-            return this;
-        }
-
-        /**
-         * Adds multiple {@link Property}s to {@link #properties}.
-         *
-         * @param properties the {@link Property}s to add
-         * @return this {@link Builder}
-         */
-        public Builder properties(Collection<Property> properties) {
-            for (Property property : properties) {
-                this.properties.put(property.getName(), property);
-            }
-            return this;
-        }
-
-        /**
-         * Adds multiple {@link Property}s to {@link #properties}.
-         *
-         * @param properties the {@link Property}s to add
-         * @return this {@link Builder}
-         */
-        public Builder properties(Property... properties) {
-            for (Property property : properties) {
-                this.properties.put(property.getName(), property);
-            }
-            return this;
-        }
-
-        /**
          * Creates a new {@link Glob} using the given {@code pattern} and assigns it to #
+         *
          * @param pattern
          * @return
          */
@@ -168,7 +133,7 @@ public class Section {
                 final String name = PropertyName.indent_size.name();
                 final PropertyType<?> type = parentBuilder.registry.getType(name);
                 final String value = "tab";
-                indentSize = new Property(type, name, value, type.parse(value), true);
+                indentSize = new Property(Collections.emptyList(), type, name, value, type.parse(value), true);
                 this.property(indentSize);
             }
 
@@ -178,7 +143,7 @@ public class Section {
                 final String name = PropertyName.tab_width.name();
                 final PropertyType<?> type = parentBuilder.registry.getType(name);
                 final String value = indentSize.getSourceValue();
-                tabWidth = new Property(type, name, value, type.parse(value), true);
+                tabWidth = new Property(Collections.emptyList(), type, name, value, type.parse(value), true);
                 this.property(tabWidth);
             }
 
@@ -187,9 +152,49 @@ public class Section {
                 final String name = PropertyName.indent_size.name();
                 final PropertyType<?> type = parentBuilder.registry.getType(name);
                 final String value = tabWidth.getSourceValue();
-                indentSize = new Property(type, name, value, type.parse(value), true);
+                indentSize = new Property(Collections.emptyList(), type, name, value, type.parse(value), true);
                 this.property(indentSize);
             }
+        }
+
+        /**
+         * Adds multiple {@link Property}s to {@link #properties}.
+         *
+         * @param properties
+         *            the {@link Property}s to add
+         * @return this {@link Builder}
+         */
+        public Builder properties(Collection<Property> properties) {
+            for (Property property : properties) {
+                this.properties.put(property.getName(), property);
+            }
+            return this;
+        }
+
+        /**
+         * Adds multiple {@link Property}s to {@link #properties}.
+         *
+         * @param properties
+         *            the {@link Property}s to add
+         * @return this {@link Builder}
+         */
+        public Builder properties(Property... properties) {
+            for (Property property : properties) {
+                this.properties.put(property.getName(), property);
+            }
+            return this;
+        }
+
+        /**
+         * Adds the given {@link Property} to {@link #properties}.
+         *
+         * @param property
+         *            the {@link Property} to add
+         * @return this {@link Builder}
+         */
+        public Builder property(Property property) {
+            this.properties.put(property.getName(), property);
+            return this;
         }
 
     }
@@ -201,14 +206,16 @@ public class Section {
     /**
      * You look for {@link #builder(PropertyTypeRegistry)} if you wonder why this constructor this package private.
      *
+     * @param adapters
      * @param glob
      * @param properties
      */
-    Section(Glob glob, List<Property> properties) {
-        super();
+    Section(List<Object> adapters, Glob glob, List<Property> properties) {
+        super(adapters);
         this.glob = glob;
         this.properties = properties;
     }
+
     public void appendTo(StringBuilder s) {
         // patterns
         if (!glob.isEmpty()) {

--- a/core/src/main/java/org/eclipse/ec4j/core/parser/EditorConfigModelHandler.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/parser/EditorConfigModelHandler.java
@@ -31,11 +31,11 @@ import org.eclipse.ec4j.core.model.propertytype.PropertyTypeRegistry;
  */
 public class EditorConfigModelHandler implements EditorConfigHandler {
 
-    private EditorConfig.Builder editorConfigBuilder;
-    private Section.Builder sectionBuilder;
-    private Property.Builder propertyBuilder;
-    private final PropertyTypeRegistry registry;
-    private final Version version;
+    protected EditorConfig.Builder editorConfigBuilder;
+    protected Section.Builder sectionBuilder;
+    protected Property.Builder propertyBuilder;
+    protected final PropertyTypeRegistry registry;
+    protected final Version version;
 
     public EditorConfigModelHandler(PropertyTypeRegistry registry, Version version) {
         this.registry = registry;

--- a/core/src/main/java/org/eclipse/ec4j/core/parser/Location.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/parser/Location.java
@@ -16,16 +16,43 @@
  */
 package org.eclipse.ec4j.core.parser;
 
+import java.util.StringTokenizer;
+
 /**
  * An immutable object that represents a location in the parsed text.
  *
  * @author <a href="mailto:angelo.zerr@gmail.com">Angelo Zerr</a>
  */
 public class Location {
+
     /**
-     * The absolute character index, starting at 0.
+     * Parses a {@link Location} from a {@link String} that has the format defined by {@link #toString()}. Should make
+     * it easier to write tests.
+     *
+     * @param locationString
+     *            the location string to parse
+     * @return a new {@link Location} parsed out of the given {@code locationString}
      */
-    public final int offset;
+    public static Location parse(String locationString) {
+        StringTokenizer st = new StringTokenizer(locationString, ": ()");
+        if (st.hasMoreTokens()) {
+            final int line = Integer.parseInt(st.nextToken());
+            if (st.hasMoreTokens()) {
+                final int column = Integer.parseInt(st.nextToken());
+                if (st.hasMoreTokens()) {
+                    final int offset = Integer.parseInt(st.nextToken());
+                    return new Location(offset, line, column);
+                }
+            }
+        }
+        throw new IllegalArgumentException(
+                "Cannot parse \"" + locationString + "\" into a " + Location.class.getName());
+    }
+
+    /**
+     * The column number, starting at 1.
+     */
+    public final int column;
 
     /**
      * The line number, starting at 1.
@@ -33,9 +60,9 @@ public class Location {
     public final int line;
 
     /**
-     * The column number, starting at 1.
+     * The absolute character index, starting at 0.
      */
-    public final int column;
+    public final int offset;
 
     Location(int offset, int line, int column) {
         this.offset = offset;
@@ -43,16 +70,7 @@ public class Location {
         this.line = line;
     }
 
-    @Override
-    public String toString() {
-        return line + ":" + column + " (" + offset + ")";
-    }
-
-    @Override
-    public int hashCode() {
-        return offset;
-    }
-
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -66,6 +84,18 @@ public class Location {
         }
         Location other = (Location) obj;
         return offset == other.offset && column == other.column && line == other.line;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return offset;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return line + ":" + column + " (" + offset + ")";
     }
 
 }

--- a/core/src/main/java/org/eclipse/ec4j/core/parser/LocationAwareModelHandler.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/parser/LocationAwareModelHandler.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2017 Angelo Zerr and other contributors as
+ * indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.ec4j.core.parser;
+
+import org.eclipse.ec4j.core.model.Version;
+import org.eclipse.ec4j.core.model.propertytype.PropertyTypeRegistry;
+
+/**
+ * An {@link EditorConfigHandler} that stores the start and end location information to the individual model elements
+ * using {@link Span} adapters and its subclasses.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public class LocationAwareModelHandler extends EditorConfigModelHandler {
+
+    private Span.Builder patternSpan;
+    private Span.Builder propertyNameSpan;
+    private Span.Builder propertyValueSpan;
+    private Span.Builder sectionSpan;
+
+    public LocationAwareModelHandler(PropertyTypeRegistry registry, Version version) {
+        super(registry, version);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void endPattern(ParseContext context, String pattern) {
+        sectionBuilder.adapter(patternSpan.end(context.getLocation()).buildPatternSpan());
+        patternSpan = null;
+        super.endPattern(context, pattern);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void endPropertyName(ParseContext context, String name) {
+        propertyBuilder.adapter(propertyNameSpan.end(context.getLocation()).buildNameSpan());
+        propertyNameSpan = null;
+        super.endPropertyName(context, name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void endPropertyValue(ParseContext context, String value) {
+        propertyBuilder.adapter(propertyValueSpan.end(context.getLocation()).buildValueSpan());
+        propertyValueSpan = null;
+        super.endPropertyValue(context, value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void endSection(ParseContext context) {
+        sectionBuilder.adapter(sectionSpan.end(context.getLocation()).buildSpan());
+        sectionSpan = null;
+        super.endSection(context);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void startPattern(ParseContext context) {
+        super.startPattern(context);
+        patternSpan = Span.builder().start(context.getLocation());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void startPropertyName(ParseContext context) {
+        super.startPropertyName(context);
+        propertyNameSpan = Span.builder().start(context.getLocation());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void startPropertyValue(ParseContext context) {
+        super.startPropertyValue(context);
+        propertyValueSpan = Span.builder().start(context.getLocation());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void startSection(ParseContext context) {
+        super.startSection(context);
+        sectionSpan = Span.builder().start(context.getLocation());
+    }
+
+}

--- a/core/src/main/java/org/eclipse/ec4j/core/parser/Span.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/parser/Span.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2017 Angelo Zerr and other contributors as
+ * indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.ec4j.core.parser;
+
+import java.util.StringTokenizer;
+
+import org.eclipse.ec4j.core.model.Property;
+import org.eclipse.ec4j.core.model.Section;
+
+/**
+ * A pair of start and end {@link Location}s. This class aggregates a few {@link Span} subclasses to be able to store
+ * multiple {@link Span}s in one model element, such as {@link NameSpan} and {@link ValueSpan} in a {@link Property}.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public class Span {
+
+    /**
+     * A {@link Span} builder.
+     */
+    public static class Builder {
+        private Location end;
+        private Location start;
+
+        /**
+         * @return a new {@link NameSpan}
+         */
+        public NameSpan buildNameSpan() {
+            return new NameSpan(start, end);
+        }
+
+        /**
+         * @return a new {@link PatternSpan}
+         */
+        public PatternSpan buildPatternSpan() {
+            return new PatternSpan(start, end);
+        }
+
+        /**
+         * @return a new {@link NameSpan}
+         */
+        public Span buildSpan() {
+            return new Span(start, end);
+        }
+
+        /**
+         * @return a new {@link ValueSpan}
+         */
+        public ValueSpan buildValueSpan() {
+            return new ValueSpan(start, end);
+        }
+
+        /**
+         * Sets the end of the {@link Span}.
+         * @param end the end {@link Location}
+         * @return this {@link Builder}
+         */
+        public Builder end(Location end) {
+            this.end = end;
+            return this;
+        }
+
+        /**
+         * Sets the start of the {@link Span}.
+         * @param start the start {@link Location}
+         * @return this {@link Builder}
+         */
+        public Builder start(Location start) {
+            this.start = start;
+            return this;
+        }
+    }
+
+    /**
+     * A subclass of {@link Span} to be able to set a span for both name and value of a {@link Property}.
+     */
+    public static class NameSpan extends Span {
+
+        private NameSpan(Location start, Location end) {
+            super(start, end);
+        }
+
+    }
+
+    /**
+     * A subclass of {@link Span} to be able to set a span for both glob and the whole secttion of a {@link Section}.
+     */
+    public static class PatternSpan extends Span {
+
+        private PatternSpan(Location start, Location end) {
+            super(start, end);
+        }
+
+    }
+
+    /**
+     * A subclass of {@link Span} to be able to set a span for both name and value of a {@link Property}.
+     */
+    public static class ValueSpan extends Span {
+
+        private ValueSpan(Location start, Location end) {
+            super(start, end);
+        }
+
+    }
+
+    /**
+     * @return a new {@link Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Parses a {@link Span} from a {@link String} that has the format defined by {@link #toString()}. Should make it
+     * easier to write tests.
+     *
+     * @param spanString
+     *            the span string to parse
+     * @return a new {@link Span} parsed out of the given {@code spanString}
+     */
+    public static Span parse(String spanString) {
+        StringTokenizer st = new StringTokenizer(spanString, "-");
+        if (st.hasMoreTokens()) {
+            final Location start = Location.parse(st.nextToken());
+            if (st.hasMoreTokens()) {
+                final Location end = Location.parse(st.nextToken());
+                return new Span(start, end);
+            }
+        }
+        throw new IllegalArgumentException("Cannot parse \"" + spanString + "\" into a " + Span.class.getName());
+    }
+
+    private final Location end;
+    private final Location start;
+
+    public Span(Location start, Location end) {
+        super();
+        this.start = start;
+        this.end = end;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Span other = (Span) obj;
+        if (end == null) {
+            if (other.end != null)
+                return false;
+        } else if (!end.equals(other.end))
+            return false;
+        if (start == null) {
+            if (other.start != null)
+                return false;
+        } else if (!start.equals(other.start))
+            return false;
+        return true;
+    }
+
+    /**
+     * @return the end {@link Location} of this {@link Span}
+     */
+    public Location getEnd() {
+        return end;
+    }
+
+    /**
+     * @return the start {@link Location} of this {@link Span}
+     */
+    public Location getStart() {
+        return start;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((end == null) ? 0 : end.hashCode());
+        result = prime * result + ((start == null) ? 0 : start.hashCode());
+        return result;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return start + " - " + end;
+    }
+}

--- a/core/src/test/java/org/eclipse/ec4j/core/ResourcesTest.java
+++ b/core/src/test/java/org/eclipse/ec4j/core/ResourcesTest.java
@@ -1,0 +1,62 @@
+package org.eclipse.ec4j.core;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+
+import org.eclipse.ec4j.core.ResourcePaths.ResourcePath;
+import org.eclipse.ec4j.core.Resources.Resource;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ResourcesTest {
+
+    @Test
+    public void ofClassPath() {
+        Resource r = Resources.ofClassPath(getClass().getClassLoader(), "/location-aware/.editorconfig", StandardCharsets.UTF_8);
+        Assert.assertNotNull(r);
+        Assert.assertEquals("/location-aware/.editorconfig", r.getPath());
+        Assert.assertTrue(r.exists());
+
+        ResourcePath parent = r.getParent();
+        Assert.assertNotNull(parent);
+        Assert.assertEquals("/location-aware", parent.getPath());
+        Assert.assertTrue(parent.hasParent());
+
+        Resource r2 = parent.resolve(".editorconfig");
+        Assert.assertNotNull(r2);
+        Assert.assertEquals("/location-aware/.editorconfig", r2.getPath());
+        Assert.assertTrue(r2.exists());
+        Assert.assertEquals(r, r2);
+
+        ResourcePath root = parent.getParent();
+        Assert.assertNotNull(root);
+        Assert.assertEquals("/", root.getPath());
+        Assert.assertFalse(root.hasParent());
+
+    }
+
+    @Test
+    public void ofPath() {
+        Resource r = Resources.ofPath(Paths.get("src/test/resources/location-aware/.editorconfig"), StandardCharsets.UTF_8);
+        Assert.assertNotNull(r);
+        Assert.assertEquals("src/test/resources/location-aware/.editorconfig", r.getPath());
+        Assert.assertTrue(r.exists());
+
+        ResourcePath parent = r.getParent();
+        Assert.assertNotNull(parent);
+        Assert.assertEquals("src/test/resources/location-aware", parent.getPath());
+        Assert.assertTrue(parent.hasParent());
+
+        Resource r2 = parent.resolve(".editorconfig");
+        Assert.assertNotNull(r2);
+        Assert.assertEquals("src/test/resources/location-aware/.editorconfig", r2.getPath());
+        Assert.assertTrue(r2.exists());
+        Assert.assertEquals(r, r2);
+
+        ResourcePath root = parent.getParent();
+        Assert.assertNotNull(root);
+        Assert.assertEquals("src/test/resources", root.getPath());
+        Assert.assertTrue(root.hasParent());
+
+    }
+}

--- a/core/src/test/java/org/eclipse/ec4j/core/parser/LocationAwareModelHandlerTest.java
+++ b/core/src/test/java/org/eclipse/ec4j/core/parser/LocationAwareModelHandlerTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2017 Angelo Zerr and other contributors as
+ * indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.ec4j.core.parser;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.ec4j.core.Resources;
+import org.eclipse.ec4j.core.Resources.Resource;
+import org.eclipse.ec4j.core.model.EditorConfig;
+import org.eclipse.ec4j.core.model.Section;
+import org.eclipse.ec4j.core.model.Version;
+import org.eclipse.ec4j.core.model.propertytype.PropertyTypeRegistry;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LocationAwareModelHandlerTest {
+
+    @Test
+    public void locations() throws IOException {
+        EditorConfig config = parse(Resources.ofClassPath(getClass().getClassLoader(), "/location-aware/.editorconfig", StandardCharsets.UTF_8));
+
+        List<Section> sections = config.getSections();
+        Assert.assertEquals(3, sections.size());
+
+        Iterator<Section> it = sections.iterator();
+        Section section = it.next();
+        // TODO Assert.assertEquals(Span.parse(""), section.getAdapter(Span.class));
+    }
+
+    private EditorConfig parse(Resource file) throws IOException {
+        EditorConfigModelHandler handler = new LocationAwareModelHandler(PropertyTypeRegistry.getDefault(), Version.CURRENT);
+        EditorConfigParser parser = EditorConfigParser.builder().build();
+        parser.parse(file, handler);
+        return handler.getEditorConfig();
+    }
+
+}

--- a/core/src/test/resources/location-aware/.editorconfig
+++ b/core/src/test/resources/location-aware/.editorconfig
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2017 Angelo Zerr and other contributors as
+# indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+
+# initial comment line 1
+# initial comment line 2
+
+# root comment line 1
+# root comment line 2
+root = true
+
+# section a before line 1
+# section a before line 2
+[*.a]
+# option1 a before line 1
+# option1 a before line 2
+option1=value1
+# option1 a after line 1
+# option1 a after line 2
+
+# section b before line 1
+# section b before line 2
+[*.b]
+# option2 a before line 1
+# option2 a before line 2
+option2=value1
+# option2 a after line 1
+# option2 a after line 2
+
+# option3 a before line 1
+# option3 a before line 2
+option3=value1
+# option3 a after line 1
+# option3 a after line 2
+
+
+[*.c]
+option4 = b
+
+# comment

--- a/services/src/main/java/org/eclipse/ec4j/services/validation/ValidationEditorConfigHandler.java
+++ b/services/src/main/java/org/eclipse/ec4j/services/validation/ValidationEditorConfigHandler.java
@@ -48,7 +48,8 @@ public class ValidationEditorConfigHandler implements EditorConfigHandler {
     private Location propertyValueStart;
     private PropertyType<?> type;
 
-    public ValidationEditorConfigHandler(IReporter reporter, ISeverityProvider provider, PropertyTypeRegistry registry) {
+    public ValidationEditorConfigHandler(IReporter reporter, ISeverityProvider provider,
+            PropertyTypeRegistry registry) {
         this.reporter = reporter;
         this.provider = provider != null ? provider : ISeverityProvider.DEFAULT;
         this.registry = registry != null ? registry : PropertyTypeRegistry.getDefault();
@@ -86,7 +87,7 @@ public class ValidationEditorConfigHandler implements EditorConfigHandler {
 
     @Override
     public void startPropertyName(ParseContext context) {
-    	this.propertyNameStart = context.getLocation();
+        this.propertyNameStart = context.getLocation();
     }
 
     @Override
@@ -104,7 +105,7 @@ public class ValidationEditorConfigHandler implements EditorConfigHandler {
 
     @Override
     public void startPropertyValue(ParseContext context) {
-    	this.propertyValueStart = context.getLocation();
+        this.propertyValueStart = context.getLocation();
     }
 
     @Override


### PR DESCRIPTION
@angelozerr this is not perfectly polished yet, just an idea how I think it could work. 

Mainly, the test is unfinished: https://github.com/angelozerr/ec4j/compare/master...ppalaga:i42?expand=1#diff-582920529e0203ec7c81702f7a6e47d3R44 In that test stub, you can see how the Location info can be accessed. 

Is the idea acceptable?

Using the adaptable pattern that you may know from Eclipse is IMO the best way to implement this. Other options like subclassing the model would lead to tons of generics. I tried it but I did not like the result. With the present solution, the default model can stay free of any non-core model info and at the same time users are free to "hang" any additional info on the model, such as model element locations.

