### PR TITLE
Fix #54 Support comments in EditorConfigParser and EditorConfigHandler

### DIFF
--- a/core/src/main/java/org/eclipse/ec4j/core/model/Comments.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/model/Comments.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) 2017 Angelo Zerr and other contributors as
+ * indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.ec4j.core.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.ec4j.core.model.Comments.CommentBlock;
+import org.eclipse.ec4j.core.model.Comments.CommentLine;
+
+/**
+ * Aggregates {@link CommentBlocks}, {@link CommentBlock} and {@link CommentLine}.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public class Comments {
+
+    /**
+     * A collection of contiguous {@link CommentLine}s.
+     */
+    public static class CommentBlock extends Adaptable {
+
+        /**
+         * A {@link CommentBlock} builder.
+         */
+        public static class Builder extends Adaptable.Builder<Builder> {
+            private List<CommentLine> commentLines = new ArrayList<>();
+            private final CommentBlocks.Builder parentBuilder;
+
+            public Builder(CommentBlocks.Builder parentBuilder) {
+                super();
+                this.parentBuilder = parentBuilder;
+            }
+
+            /**
+             * @return a new {@link CommentBlock}
+             */
+            public CommentBlock build() {
+                List<CommentLine> useComments = Collections.unmodifiableList(this.commentLines);
+                this.commentLines = null;
+                return new CommentBlock(sealAdapters(), useComments);
+            }
+
+            /**
+             * Calls {@link #build()}, passes the result to {@link #parentBuilder} and returns {@link #parentBuilder}.
+             *
+             * @return {@link #parentBuilder}
+             */
+            public CommentBlocks.Builder closeCommentBlock() {
+                return parentBuilder.commentBlock(build());
+            }
+
+            /**
+             * Adds a single {@link CommentLine}.
+             *
+             * @param commentLine
+             *            the {@link CommentLine} to add
+             * @return this {@link Builder}
+             */
+            public Builder commentLine(CommentLine commentLine) {
+                this.commentLines.add(commentLine);
+                return this;
+            }
+
+            /**
+             * Adds multiple {@link CommentLine}s.
+             *
+             * @param commentLines
+             *            the {@link CommentLine}s to add
+             * @return this {@link Builder}
+             */
+            public Builder commentLines(Collection<CommentLine> commentLines) {
+                this.commentLines.addAll(commentLines);
+                return this;
+            }
+
+            /**
+             * Adds multiple {@link CommentLine}s.
+             *
+             * @param commentLines
+             *            the {@link CommentLine}s to add
+             * @return this {@link Builder}
+             */
+            public Builder commentLines(CommentLine... comments) {
+                for (CommentLine commentLine : comments) {
+                    this.commentLines.add(commentLine);
+                }
+                return this;
+            }
+
+            /**
+             * @return a new {@link CommentLine.Builder}
+             */
+            public CommentLine.Builder openCommentLine() {
+                return new CommentLine.Builder(this);
+            }
+        }
+
+        private final List<CommentLine> commentLines;
+
+        CommentBlock(List<Object> adapters, List<CommentLine> commentLines) {
+            super(adapters);
+            this.commentLines = commentLines;
+        }
+
+        /**
+         * @return an unmodifiable {@link List} of {@link CommentLine}s
+         */
+        public List<CommentLine> getCommentLines() {
+            return commentLines;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            for (CommentLine commentLine : commentLines) {
+                sb.append(commentLine).append('\n');
+            }
+            return sb.toString();
+        }
+
+    }
+
+    /**
+     * A collection of {@link CommentBlock}s.
+     */
+    public static class CommentBlocks extends Adaptable {
+
+        /**
+         * A {@link CommentBlocks} builder.
+         */
+        public static class Builder extends Adaptable.Builder<Builder> {
+            private List<CommentBlock> commentBlocks = new ArrayList<>();
+
+            /**
+             * @return new {@link CommentBlocks}
+             */
+            public CommentBlocks build() {
+                return new CommentBlocks(sealAdapters(), commentBlocks);
+            }
+
+            /**
+             * Adds a single {@link CommentBlock}.
+             *
+             * @param commentBlock
+             *            the {@link CommentBlock} to add
+             * @return this {@link Builder}
+             */
+            public Builder commentBlock(CommentBlock commentBlock) {
+                this.commentBlocks.add(commentBlock);
+                return this;
+            }
+
+            /**
+             * Adds multiple {@link CommentBlock}s.
+             *
+             * @param commentBlocks
+             *            the {@link CommentBlock}s to add
+             * @return this {@link Builder}
+             */
+            public Builder commentBlocks(Collection<CommentBlock> commentBlocks) {
+                this.commentBlocks.addAll(commentBlocks);
+                return this;
+            }
+
+            /**
+             * Adds multiple {@link CommentBlock}s.
+             *
+             * @param commentBlocks
+             *            the {@link CommentBlock}s to add
+             * @return this {@link Builder}
+             */
+            public Builder commentBlocks(CommentBlock... comments) {
+                for (CommentBlock commentBlock : comments) {
+                    this.commentBlocks.add(commentBlock);
+                }
+                return this;
+            }
+
+            /**
+             * @return new {@link CommentBlock.Builder}
+             */
+            public CommentBlock.Builder openCommentBlock() {
+                return new CommentBlock.Builder(this);
+            }
+        }
+
+        /**
+         * @return a new {@link Builder}
+         */
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        private final List<CommentBlock> commentBlocks;
+
+        public CommentBlocks(List<Object> adapters, List<CommentBlock> commentBlocks) {
+            super(adapters);
+            this.commentBlocks = commentBlocks;
+        }
+
+        /**
+         * @return an unmodifiable {@link List} of {@link CommentBlock}s
+         */
+        public List<CommentBlock> getCommentBlocks() {
+            return commentBlocks;
+        }
+    }
+
+    /**
+     * A single comment line.
+     */
+    public static class CommentLine extends Adaptable {
+
+        /**
+         * A {@link CommentLine} builder.
+         */
+        public static class Builder extends Adaptable.Builder<Builder> {
+            private final CommentBlock.Builder parentBuilder;
+            private String text;
+
+            Builder(CommentBlock.Builder parentBuilder) {
+                super();
+                this.parentBuilder = parentBuilder;
+            }
+
+            /**
+             * @return a new {@link CommentLine}
+             */
+            public CommentLine build() {
+                return new CommentLine(sealAdapters(), text);
+            }
+
+            /**
+             * Calls {@link #build()}, passes the result to {@link #parentBuilder} and returns the
+             * {@link #parentBuilder}
+             *
+             * @return {@link #parentBuilder}
+             */
+            public CommentBlock.Builder closeComment() {
+                return parentBuilder.commentLine(build());
+            }
+
+            /**
+             * @param text
+             *            the comment text
+             * @return this {@link Builder}
+             */
+            public Builder text(String text) {
+                this.text = text;
+                return this;
+            }
+        }
+
+        private final String text;
+
+        CommentLine(List<Object> adapters, String text) {
+            super(adapters);
+            this.text = text;
+        }
+
+        /**
+         * @return the text of the comment
+         */
+        public String getText() {
+            return text;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String toString() {
+            return text;
+        }
+
+    }
+
+}

--- a/core/src/main/java/org/eclipse/ec4j/core/parser/EditorConfigHandler.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/parser/EditorConfigHandler.java
@@ -111,7 +111,8 @@ public interface EditorConfigHandler {
      *
      * @param context
      *            the {@link ParseContext}
-     * @param name the name
+     * @param name
+     *            the name
      */
     void endPropertyName(ParseContext context, String name);
 
@@ -128,15 +129,43 @@ public interface EditorConfigHandler {
      *
      * @param context
      *            the {@link ParseContext}
-     * @param value the value
+     * @param value
+     *            the value
      */
     void endPropertyValue(ParseContext context, String value);
 
     /**
      * A {@link ParseException} occured
      *
-     * @param e the error
+     * @param e
+     *            the error
      */
     void error(ParseException e);
+
+    /**
+     * Start of a comment line
+     *
+     * @param context
+     *            the {@link ParseContext}
+     */
+    void startComment(ParseContext context);
+
+    /**
+     * End of a comment line
+     *
+     * @param context
+     *            the {@link ParseContext}
+     * @param comment
+     *            the comment text
+     */
+    void endComment(ParseContext context, String comment);
+
+    /**
+     * A blank line
+     *
+     * @param context
+     *            the {@link ParseContext}
+     */
+    void blankLine(ParseContext context);
 
 }

--- a/core/src/main/java/org/eclipse/ec4j/core/parser/EditorConfigModelHandler.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/parser/EditorConfigModelHandler.java
@@ -90,7 +90,9 @@ public class EditorConfigModelHandler implements EditorConfigHandler {
      * @return the {@link EditorConfig} instance parsed out of the event stream
      */
     public EditorConfig getEditorConfig() {
-        return editorConfigBuilder.build();
+        EditorConfig result = editorConfigBuilder.build();
+        editorConfigBuilder = null;
+        return result;
     }
 
     /** {@inheritDoc} */
@@ -124,6 +126,21 @@ public class EditorConfigModelHandler implements EditorConfigHandler {
     @Override
     public void endPropertyValue(ParseContext context, String value) {
         propertyBuilder.value(value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void startComment(ParseContext context) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void endComment(ParseContext context, String comment) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void blankLine(ParseContext context) {
     }
 
 }

--- a/core/src/main/java/org/eclipse/ec4j/core/parser/EditorConfigParser.java
+++ b/core/src/main/java/org/eclipse/ec4j/core/parser/EditorConfigParser.java
@@ -158,8 +158,12 @@ public class EditorConfigParser implements ParseContext {
 
     private void readLineAndThrowExceptionIfError() throws IOException {
         skipWhiteSpace();
-        if (isNewLine() || current == '\ufeff') {
-            // blank line, or BOM character, do nothing
+        if (isNewLine()) {
+            // blank line
+            handler.blankLine(this);
+            return;
+        } else if (current == '\ufeff') {
+            // BOM character, do nothing
             return;
         }
         switch (current) {
@@ -179,9 +183,12 @@ public class EditorConfigParser implements ParseContext {
     }
 
     private void readComment() throws IOException {
+        handler.startComment(this);
+        startCapture();
         do {
             read();
         } while (!isEndOfText() && !isNewLine());
+        handler.endComment(this, endCapture());
     }
 
     private void readSection() throws IOException {

--- a/core/src/test/java/org/eclipse/ec4j/core/ResourcesTest.java
+++ b/core/src/test/java/org/eclipse/ec4j/core/ResourcesTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) 2017 Angelo Zerr and other contributors as
+ * indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.eclipse.ec4j.core;
 
 import java.nio.charset.StandardCharsets;

--- a/core/src/test/java/org/eclipse/ec4j/core/parser/LocationAwareModelHandlerTest.java
+++ b/core/src/test/java/org/eclipse/ec4j/core/parser/LocationAwareModelHandlerTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.eclipse.ec4j.core.Resources;
 import org.eclipse.ec4j.core.Resources.Resource;
+import org.eclipse.ec4j.core.model.Comments.CommentBlocks;
 import org.eclipse.ec4j.core.model.EditorConfig;
 import org.eclipse.ec4j.core.model.Section;
 import org.eclipse.ec4j.core.model.Version;
@@ -35,6 +36,10 @@ public class LocationAwareModelHandlerTest {
     @Test
     public void locations() throws IOException {
         EditorConfig config = parse(Resources.ofClassPath(getClass().getClassLoader(), "/location-aware/.editorconfig", StandardCharsets.UTF_8));
+
+        CommentBlocks commentBlocks = config.getAdapter(CommentBlocks.class);
+        Assert.assertNotNull(commentBlocks);
+        Assert.assertEquals(12, commentBlocks.getCommentBlocks().size());
 
         List<Section> sections = config.getSections();
         Assert.assertEquals(3, sections.size());

--- a/services/src/main/java/org/eclipse/ec4j/services/validation/ValidationEditorConfigHandler.java
+++ b/services/src/main/java/org/eclipse/ec4j/services/validation/ValidationEditorConfigHandler.java
@@ -147,4 +147,16 @@ public class ValidationEditorConfigHandler implements EditorConfigHandler {
     public void endProperty(ParseContext context) {
 
     }
+
+    @Override
+    public void startComment(ParseContext context) {
+    }
+
+    @Override
+    public void endComment(ParseContext context, String comment) {
+    }
+
+    @Override
+    public void blankLine(ParseContext context) {
+    }
 }


### PR DESCRIPTION
@angelozerr could you please have a look? 

The idea is the following:

* Contiguous comment lines are grouped to a `CommentBlock`
* All `CommentBlock` s of a document are hanged onto the `EditorConfig` as ` CommentBlocks`

See the test: https://github.com/angelozerr/ec4j/compare/master...ppalaga:i54?expand=1#diff-582920529e0203ec7c81702f7a6e47d3R40

Is this good enough for what you need?